### PR TITLE
Fix/distutils depr

### DIFF
--- a/pbincli/cli.py
+++ b/pbincli/cli.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 import os, sys, argparse
-# from distutils.util import strtobool
 
 import pbincli.actions
 from pbincli.api import PrivateBin

--- a/pbincli/cli.py
+++ b/pbincli/cli.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 import os, sys, argparse
-from distutils.util import strtobool
+# from distutils.util import strtobool
 
 import pbincli.actions
 from pbincli.api import PrivateBin
-from pbincli.utils import PBinCLIException, PBinCLIError, validate_url_ending
+from pbincli.utils import PBinCLIException, PBinCLIError, validate_url_ending, strtobool
 
 CONFIG_PATHS = [
     os.path.join(".", "pbincli.conf", ),
@@ -27,7 +27,7 @@ def read_config(filename):
             try:
                 key, value = l.strip().split("=", 1)
                 if value.strip().lower() in ['true', 'false']:
-                    settings[key.strip()] = bool(strtobool(value.strip()))
+                    settings[key.strip()] = strtobool(value.strip().lower())
                 else:
                     settings[key.strip()] = value.strip()
             except ValueError:

--- a/pbincli/utils.py
+++ b/pbincli/utils.py
@@ -54,3 +54,11 @@ def uri_validator(x):
         return result, isuri
     except ValueError:
         return False
+
+def strtobool(str):
+    if str == 'true':
+        return True
+    else if str == 'false':
+        return False
+    else:
+        raise ValueError(f"Tried to call strtobool on a value that does not equal a bool: {str}")

--- a/pbincli/utils.py
+++ b/pbincli/utils.py
@@ -58,7 +58,7 @@ def uri_validator(x):
 def strtobool(str):
     if str == 'true':
         return True
-    else if str == 'false':
+    elif str == 'false':
         return False
     else:
         raise ValueError(f"Tried to call strtobool on a value that does not equal a bool: {str}")


### PR DESCRIPTION
This is a fix to remove the need for the `distutils` package, which has been deprecated since Python 3.10 and has been removed since Python 3.12. This created a `module not found` error for users with Python >=3.12.